### PR TITLE
Include ids in lemma queries

### DIFF
--- a/app/services/lemma_service.py
+++ b/app/services/lemma_service.py
@@ -17,7 +17,9 @@ def _build_lemma_query(lemma: str) -> dict:
         flags = pattern_match.group(2) or ""
         return {"headword.lemma": {"$regex": pattern, "$options": flags}}
     else:
-        return {"headword.lemma": lemma}
+        return {
+            "$or": [{"headword.lemma": lemma}, {"sourceId": lemma}, {"lexId": lemma}]
+        }
 
 
 dispatcher = {


### PR DESCRIPTION
Allows users to search for exact lemma ids (`sourceId` or `lexId`) with the lemma field. Since including the id fields in regex queries may lead to over-retrieval, ids are only considered in verbatim queries (the default). In the future, we may create a dedicated id form.