### PR TITLE
Update insert_attribute

### DIFF
--- a/app/transformers/bdo/bdo_mixed_content.py
+++ b/app/transformers/bdo/bdo_mixed_content.py
@@ -58,7 +58,7 @@ class BdoBaseTransformer(StandoffTransformer):
 
         return (
             aframe.assign(ref_type=mapped_ref_types)
-            .insert_attribute("verweis", "ref_type")
+            .insert_attribute("ref_type", "verweis")
             .drop("ref_type", axis=1)
         )
 
@@ -96,7 +96,7 @@ class BdoBaseTransformer(StandoffTransformer):
 class BdoLiteratureTransformer(StandoffTransformer):
     @preprocess(order=1)
     def insert_literature_prefixes(self, aframe: AnnotationFrame) -> AnnotationFrame:
-        return aframe.insert_attribute("literatur-quelle", "quelle-art")
+        return aframe.insert_attribute("quelle-art", "literatur-quelle")
 
     @preprocess(order=3)
     def add_bib_id_column(self, aframe: AnnotationFrame) -> AnnotationFrame:

--- a/app/transformers/bdo/bdo_mixed_content.py
+++ b/app/transformers/bdo/bdo_mixed_content.py
@@ -96,7 +96,7 @@ class BdoBaseTransformer(StandoffTransformer):
 class BdoLiteratureTransformer(StandoffTransformer):
     @preprocess(order=1)
     def insert_literature_prefixes(self, aframe: AnnotationFrame) -> AnnotationFrame:
-        return aframe.pluck_attribute("literatur-quelle", "quelle-art")
+        return aframe.pluck_attribute("literatur-quelle", "quelle-art", padding="right")
 
     @preprocess(order=3)
     def add_bib_id_column(self, aframe: AnnotationFrame) -> AnnotationFrame:

--- a/app/transformers/bdo/bdo_mixed_content.py
+++ b/app/transformers/bdo/bdo_mixed_content.py
@@ -96,7 +96,7 @@ class BdoBaseTransformer(StandoffTransformer):
 class BdoLiteratureTransformer(StandoffTransformer):
     @preprocess(order=1)
     def insert_literature_prefixes(self, aframe: AnnotationFrame) -> AnnotationFrame:
-        return aframe.insert_attribute("literatur-quelle", "quelle-art")
+        return aframe.pluck_attribute("literatur-quelle", "quelle-art")
 
     @preprocess(order=3)
     def add_bib_id_column(self, aframe: AnnotationFrame) -> AnnotationFrame:

--- a/app/transformers/bdo/bdo_mixed_content.py
+++ b/app/transformers/bdo/bdo_mixed_content.py
@@ -58,7 +58,7 @@ class BdoBaseTransformer(StandoffTransformer):
 
         return (
             aframe.assign(ref_type=mapped_ref_types)
-            .insert_attribute("ref_type", "verweis")
+            .insert_attribute("verweis", "ref_type")
             .drop("ref_type", axis=1)
         )
 
@@ -96,7 +96,7 @@ class BdoBaseTransformer(StandoffTransformer):
 class BdoLiteratureTransformer(StandoffTransformer):
     @preprocess(order=1)
     def insert_literature_prefixes(self, aframe: AnnotationFrame) -> AnnotationFrame:
-        return aframe.insert_attribute("quelle-art", "literatur-quelle")
+        return aframe.insert_attribute("literatur-quelle", "quelle-art")
 
     @preprocess(order=3)
     def add_bib_id_column(self, aframe: AnnotationFrame) -> AnnotationFrame:

--- a/app/transformers/standoff/annotation_frame.py
+++ b/app/transformers/standoff/annotation_frame.py
@@ -182,7 +182,7 @@ class AnnotationFrame(pd.DataFrame):
 
         spans = self.get_spans(tag).dropna(subset=[attribute]).index
 
-        new_frame = self.copy()
+        new_frame: AnnotationFrame = self.copy()
 
         for tag_id in spans:
             span = new_frame.get_span(tag_id)

--- a/app/transformers/standoff/annotation_frame.py
+++ b/app/transformers/standoff/annotation_frame.py
@@ -215,7 +215,7 @@ class AnnotationFrame(pd.DataFrame):
 
         return new_frame
 
-    def annotate_span(self, start: int, end: int, tag: str):
+    def annotate_span(self, start: int, end: int, tag: str) -> "AnnotationFrame":
         text = self.get_root().text[start:end]
         id_ = self.index.max() + 1
         anno_data = {

--- a/app/transformers/standoff/annotation_frame.py
+++ b/app/transformers/standoff/annotation_frame.py
@@ -177,6 +177,7 @@ class AnnotationFrame(pd.DataFrame):
         return new_frame
 
     def insert_attribute(self, attribute: str, tag: str) -> "AnnotationFrame":
+        """Take the values of an annotation layer and insert them into the base text"""
         if attribute not in self.columns:
             return self
 

--- a/app/transformers/standoff/annotation_frame.py
+++ b/app/transformers/standoff/annotation_frame.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import pandas as pd
 
@@ -20,6 +20,9 @@ def _insert_text(row, position, text):
     offset = row.start
     position -= offset
     return row.text[:position] + text + row.text[position:]
+
+
+Padding = Literal["both", "left", "right"]
 
 
 class AnnotationFrame(pd.DataFrame):
@@ -176,8 +179,13 @@ class AnnotationFrame(pd.DataFrame):
 
         return new_frame
 
-    def pluck_attribute(self, tag: str, attribute: str) -> "AnnotationFrame":
-        """Take the values of an annotation layer and insert them into the base text"""
+    def pluck_attribute(
+        self, tag: str, attribute: str, padding: Padding | None = None
+    ) -> "AnnotationFrame":
+        """
+        Take the values of an annotation layer and insert them into the base text.
+        Mark inserted spans with special plucked: annotations.
+        """
         if attribute not in self.columns:
             return self
 
@@ -188,7 +196,22 @@ class AnnotationFrame(pd.DataFrame):
         for tag_id in spans:
             span = new_frame.get_span(tag_id)
             value = span[attribute]
-            new_frame = new_frame.insert_text(span.start, f"{value} ")
+
+            match padding:
+                case "both":
+                    value = f" {value} "
+                case "left":
+                    value = f" {value}"
+                case "right":
+                    value = f"{value} "
+
+            new_frame = new_frame.insert_text(span.start, value)
+
+            new_frame = new_frame.annotate_span(
+                span.start,
+                span.start + len(value),
+                f"plucked:{tag}/{attribute}",
+            )
 
         return new_frame
 

--- a/app/transformers/standoff/annotation_frame.py
+++ b/app/transformers/standoff/annotation_frame.py
@@ -176,7 +176,7 @@ class AnnotationFrame(pd.DataFrame):
 
         return new_frame
 
-    def insert_attribute(self, tag: str, attribute: str) -> "AnnotationFrame":
+    def pluck_attribute(self, tag: str, attribute: str) -> "AnnotationFrame":
         """Take the values of an annotation layer and insert them into the base text"""
         if attribute not in self.columns:
             return self

--- a/app/transformers/standoff/annotation_frame.py
+++ b/app/transformers/standoff/annotation_frame.py
@@ -176,7 +176,7 @@ class AnnotationFrame(pd.DataFrame):
 
         return new_frame
 
-    def insert_attribute(self, attribute: str, tag: str) -> "AnnotationFrame":
+    def insert_attribute(self, tag: str, attribute: str) -> "AnnotationFrame":
         """Take the values of an annotation layer and insert them into the base text"""
         if attribute not in self.columns:
             return self

--- a/app/transformers/standoff/annotation_frame.py
+++ b/app/transformers/standoff/annotation_frame.py
@@ -176,7 +176,7 @@ class AnnotationFrame(pd.DataFrame):
 
         return new_frame
 
-    def insert_attribute(self, tag: str, attribute: str) -> "AnnotationFrame":
+    def insert_attribute(self, attribute: str, tag: str) -> "AnnotationFrame":
         if attribute not in self.columns:
             return self
 

--- a/app/transformers/standoff/annotation_frame.py
+++ b/app/transformers/standoff/annotation_frame.py
@@ -192,6 +192,21 @@ class AnnotationFrame(pd.DataFrame):
 
         return new_frame
 
+    def annotate_span(self, start: int, end: int, tag: str):
+        text = self.get_root().text[start:end]
+        id_ = self.index.max() + 1
+        anno_data = {
+            "start": start,
+            "end": end,
+            "depth": 1,
+            "tag": tag,
+            "text": text,
+        }
+
+        new_annotation = pd.DataFrame.from_dict({id_: anno_data}, orient="index")
+
+        return pd.concat([self, new_annotation])
+
     def validate(self, debug: bool = False) -> "AnnotationFrame":
         text_by_index = self.apply(
             lambda row: self._roottext[row.start : row.end], axis=1

--- a/app/transformers/standoff/standoff_transformer.py
+++ b/app/transformers/standoff/standoff_transformer.py
@@ -48,9 +48,9 @@ class StandoffTransformer:
     @classmethod
     def _init_dataframe(cls, span_data: list[dict]) -> pd.DataFrame:
         frame = pd.DataFrame(
-            span_data, columns=["start", "end", "depth", "tag", "attributes", "text"]
+            span_data, columns=["start", "end", "depth", "tag", "_attributes", "text"]
         )
-        extra_attributes = pd.DataFrame.from_records(frame.pop("attributes"))
+        extra_attributes = pd.DataFrame.from_records(frame.pop("_attributes"))
         frame = pd.concat([frame, extra_attributes], axis=1)
 
         frame = cls._add_unique_ids(frame)


### PR DESCRIPTION
Fix #35 by auto-adding special annotations (prefixed by `plucked:`) when extracting and inserting annotation attributes into the base text