### PR TITLE
Add plucked attribute registration

### DIFF
--- a/app/models/annotated_text.py
+++ b/app/models/annotated_text.py
@@ -50,6 +50,7 @@ AnnotationSpan = Annotated[
         BibRefAnnotationSpan,
         CrossRefAnnotationSpan,
         LinkAnnotationSpan,
+        XmlAttributeSpan,
     ],
     Field(discriminator="type"),
 ]

--- a/app/models/annotated_text.py
+++ b/app/models/annotated_text.py
@@ -37,6 +37,13 @@ class CrossRefAnnotationSpan(LinkAnnotationSpan):
     missing: Optional[bool] = False
 
 
+class XmlAttributeSpan(BaseAnnotationSpan):
+    type: Literal["xmlattribute"]
+    from_tag: str = Field(alias="fromTag")
+    from_attribute: str = Field(alias="fromAttribute")
+    value: str
+
+
 AnnotationSpan = Annotated[
     Union[
         TextAnnotationSpan,

--- a/app/transformers/bdo/bdo_mixed_content.py
+++ b/app/transformers/bdo/bdo_mixed_content.py
@@ -96,7 +96,9 @@ class BdoBaseTransformer(StandoffTransformer):
 class BdoLiteratureTransformer(StandoffTransformer):
     @preprocess(order=1)
     def insert_literature_prefixes(self, aframe: AnnotationFrame) -> AnnotationFrame:
-        return aframe.pluck_attribute("literatur-quelle", "quelle-art", padding="right")
+        return self.pluck_attribute(
+            aframe, "literatur-quelle", "quelle-art", padding="right"
+        )
 
     @preprocess(order=3)
     def add_bib_id_column(self, aframe: AnnotationFrame) -> AnnotationFrame:

--- a/app/transformers/standoff/annotation_frame.py
+++ b/app/transformers/standoff/annotation_frame.py
@@ -25,6 +25,17 @@ def _insert_text(row, position, text):
 Padding = Literal["both", "left", "right"]
 
 
+def add_padding(text: str, padding: Padding | None):
+    match padding:
+        case "both":
+            return f" {text} "
+        case "left":
+            return f" {text}"
+        case "right":
+            return f"{text} "
+    return text
+
+
 class AnnotationFrame(pd.DataFrame):
     _metadata = ["_deleted_spans"]
 
@@ -196,26 +207,22 @@ class AnnotationFrame(pd.DataFrame):
         for tag_id in spans:
             span = new_frame.get_span(tag_id)
             value = span[attribute]
+            insertion = add_padding(value, padding)
 
-            match padding:
-                case "both":
-                    value = f" {value} "
-                case "left":
-                    value = f" {value}"
-                case "right":
-                    value = f"{value} "
-
-            new_frame = new_frame.insert_text(span.start, value)
+            new_frame = new_frame.insert_text(span.start, insertion)
 
             new_frame = new_frame.annotate_span(
                 span.start,
-                span.start + len(value),
+                span.start + len(insertion),
                 f"*{tag}/@{attribute}",
+                value=value,
             )
 
         return new_frame
 
-    def annotate_span(self, start: int, end: int, tag: str) -> "AnnotationFrame":
+    def annotate_span(
+        self, start: int, end: int, tag: str, **kwargs
+    ) -> "AnnotationFrame":
         text = self.get_root().text[start:end]
         max_id = (
             self.get_spans(tag).index.str.rsplit("_", n=1).str[-1].astype(int).max()
@@ -226,6 +233,7 @@ class AnnotationFrame(pd.DataFrame):
             "depth": 1,
             "tag": tag,
             "text": text,
+            **kwargs,
         }
 
         new_annotation = pd.DataFrame.from_dict(

--- a/app/transformers/standoff/standoff_transformer.py
+++ b/app/transformers/standoff/standoff_transformer.py
@@ -2,6 +2,7 @@ from typing import Any, Callable
 
 import pandas as pd
 
+from app.models.annotated_text import XmlAttributeSpan
 from app.transformers.standoff.annotation_frame import AnnotationFrame
 from app.transformers.standoff.xml_standoff_converter import (
     xml_to_standoff,
@@ -30,6 +31,10 @@ def register(tag: str):
         return func
 
     return decorator
+
+
+def basedata(span, type_: str) -> dict:
+    return {"type": type_, **span[["start", "end", "text"]].to_dict()}
 
 
 class StandoffTransformer:
@@ -113,3 +118,21 @@ class StandoffTransformer:
     def serialize(self) -> dict:
         result = {"text": self.aframe._roottext, "annotations": self._serialize_spans()}
         return result
+
+    def _register_plucked_attribute(self, tag: str, attribute: str):
+        def serialize_attribute(_, span) -> XmlAttributeSpan:
+            return XmlAttributeSpan(
+                **basedata(span, "xmlattribute"),
+                fromTag=tag,
+                fromAttribute=attribute,
+                value=span.value,
+            )
+
+        self._tag_handlers[f"*{tag}/@{attribute}"] = serialize_attribute
+
+    def pluck_attribute(
+        self, aframe: AnnotationFrame, tag: str, attribute: str, padding="right"
+    ) -> AnnotationFrame:
+        """Pull an xml attribute value into the base text and register serialization method"""
+        self._register_plucked_attribute(tag, attribute)
+        return aframe.pluck_attribute(tag, attribute, padding)


### PR DESCRIPTION
Add automatic registration and serialization of plucked attribute annotations.

## Explanation

`AnnotationFrame.pluck_attribute` would retrieve a specified xml attribute, pull its value into the source text, and add an annotation, e.g., to extract `cf.` from cases similar to the example below:

```xml
<example>
    For an overview, <ref type="cf.">Smith (2000)</ref>.
</example>
```
The aim is to infer the correct base text for further processing, which includes "cf.". In order to explicitly mark text segments inserted this way, a special annotation prefixed with an asterisk `*` is added (borrowing from the historical linguistics convention of marking reconstructed forms - this might change in the future). To further reduce ambiguity between automatic and original annotations, a new `XmlAttributeSpan` annotation type is added.

Even with the annotation being added, it does not show up in the transformed JSON output unless a registered (decorated with `@register`) serialization method is written. Since adding it by hand is verbose and easy to miss, this PR implements automatic registration of plucked attribute annotations.