### PR TITLE
Update transformation metadata and optimize

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -51,7 +51,7 @@ app.add_middleware(
 )
 
 
-@app.get("/lemma/{lemma_id}", tags=["Search"])
+@app.get("/lemma/{lemma_id:path}", tags=["Search"])
 def fetch_lemma_display_entry(lemma_id: str = "bwb__Datschi") -> Entry:
     return app.state.query_service.fetch_lemma_display(lemma_id)
 

--- a/app/models/entry.py
+++ b/app/models/entry.py
@@ -1,5 +1,6 @@
+from datetime import date
 from enum import Enum
-from typing import Literal, Optional
+from typing import Optional
 
 from pydantic import Field
 
@@ -101,6 +102,8 @@ class Headword(BaseModel):
 class Entry(BaseModel, GrammaticalFeatures):
     headword: Headword
     lex_id: str = Field(alias="lexId")
+    retrieved_at: Optional[date] | None = Field(alias="retrievedAt", default=None)
+    uploaded_at: Optional[date] | None = Field(alias="uploadedAt", default=None)
     source_id: Optional[str] = Field(alias="sourceId", default=None)
     source: Resource
     original_source: Optional[str] = Field(alias="originalSource", default=None)

--- a/app/transformers/base_xml_transformer.py
+++ b/app/transformers/base_xml_transformer.py
@@ -21,29 +21,6 @@ def extract_text(node) -> str | None:
 
 
 class BaseXmlTransformer:
-    def __init__(self):
-        self._lex_ids = Counter()
-
-    def _add_lex_id(self, entry: dict) -> dict:
-        pos_abbreviations = {"Substantiv": "n", "Verb": "v", "Adjektiv": "a"}
-        lemma_index = entry["headword"]["index"]
-        lemma = unidecode(entry["headword"]["lemma"].lower())
-
-        lex_id = "__".join(
-            [
-                "lex",
-                entry["source"] or "",
-                f"{lemma}{'' if lemma_index == 0 else lemma_index}",
-                pos_abbreviations.get(entry.get("nPos"), "o"),  # o = other
-            ]
-        )
-        self._lex_ids[lex_id] += 1
-
-        if (count := self._lex_ids[lex_id]) > 1:
-            lex_id += f"__{count}"
-
-        return {**entry, "lexId": lex_id}
-
     def _prepare_tree(self, root):
         """Hook for subclasses to modify the parsed tree before extraction.
 
@@ -81,7 +58,7 @@ class BaseXmlTransformer:
 
         result = self.postprocess(result, element)
 
-        return self._add_lex_id(result)
+        return result
 
     def postprocess(self, data: dict, element: ET._Element) -> dict:
         """Hook for modifying transformed data.

--- a/app/transformers/bdo/bdo_transformer.py
+++ b/app/transformers/bdo/bdo_transformer.py
@@ -59,7 +59,7 @@ class BdoXmlTransformer(BaseXmlTransformer):
     @xpath(".//lemma", default="")
     def headword(self, lemma_node):
         return {
-            "lemma": lemma_node.text or "",
+            "lemma": lemma_node.text,
             "index": int(getattr(lemma_node.find("hoch"), "text", "0")),
         }
 

--- a/app/transformers/bdo/bdo_transformer.py
+++ b/app/transformers/bdo/bdo_transformer.py
@@ -59,7 +59,7 @@ class BdoXmlTransformer(BaseXmlTransformer):
     @xpath(".//lemma", default="")
     def headword(self, lemma_node):
         return {
-            "lemma": lemma_node.text,
+            "lemma": lemma_node.text or "",
             "index": int(getattr(lemma_node.find("hoch"), "text", "0")),
         }
 

--- a/app/transformers/lex_transformer.py
+++ b/app/transformers/lex_transformer.py
@@ -1,4 +1,6 @@
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import date
+from os import cpu_count
 from pathlib import Path
 from typing import Iterator, Optional
 
@@ -27,26 +29,75 @@ def create_id(namespace: str, source_dir: Path, filepath: Path | str):
     return f"{namespace}:{subpath}"
 
 
-def transform(
-    xml_dir: Path, resource_name: str, *, retrieved_at: date | None = None
-) -> Iterator[dict]:
+def _process_single_file(
+    filepath: Path,
+    resource_name: str,
+    xml_dir: Path,
+    retrieved_at: date | None = None,
+) -> dict:
+    """Process a single XML file."""
     Transformer = TRANSFORMER_REGISTRY[resource_name]()  # noqa: N806
+    result = Transformer.transform(filepath)
+    result["lexId"] = create_id(
+        namespace=resource_name, source_dir=xml_dir, filepath=filepath
+    )
 
+    if retrieved_at is not None:
+        result["retrievedAt"] = retrieved_at.isoformat()
+
+    return result
+
+
+def transform(
+    xml_dir: Path,
+    resource_name: str,
+    *,
+    retrieved_at: date | None = None,
+    num_workers: int | None = None,
+) -> Iterator[dict]:
+    """Transform XML files to LexoTerm format with optional multiprocessing.
+
+    Args:
+        xml_dir: Directory containing XML files
+        resource_name: Name of the resource transformer to use
+        retrieved_at: Optional retrieval date
+        num_workers: Number of worker processes. Defaults to CPU count.
+                    Set to 1 to disable multiprocessing.
+    """
     files = list(xml_dir.rglob("*.xml"))
-    progress_bar = tqdm(files, desc="Converting XML to LexoTerm format")
 
-    for filepath in progress_bar:
-        progress_bar.set_description(f"Processing {filepath.parent.parent.name}")
+    if num_workers is None:
+        num_workers = cpu_count() or 4
 
-        result = Transformer.transform(filepath)
-        result["lexId"] = create_id(
-            namespace=resource_name, source_dir=xml_dir, filepath=filepath
-        )
+    if num_workers == 1:
+        progress_bar = tqdm(files, desc="Converting XML to LexoTerm format")
+        for filepath in progress_bar:
+            progress_bar.set_description(f"Processing {filepath.parent.parent.name}")
+            result = _process_single_file(
+                filepath, resource_name, xml_dir, retrieved_at
+            )
+            yield result
+    else:
+        with ProcessPoolExecutor(max_workers=num_workers) as executor:
+            progress_bar = tqdm(
+                total=len(files), desc="Converting XML to LexoTerm format"
+            )
 
-        if retrieved_at is not None:
-            result["retrievedAt"] = retrieved_at.isoformat()
+            futures = {
+                executor.submit(
+                    _process_single_file, filepath, resource_name, xml_dir, retrieved_at
+                ): filepath
+                for filepath in files
+            }
 
-        yield result
+            for future in as_completed(futures):
+                filepath = futures[future]
+                progress_bar.set_description(
+                    f"Processing {filepath.parent.parent.name}"
+                )
+                result = future.result()
+                progress_bar.update(1)
+                yield result
 
 
 if __name__ == "__main__":

--- a/app/transformers/lex_transformer.py
+++ b/app/transformers/lex_transformer.py
@@ -15,25 +15,39 @@ def ensure_output_directories():
     OUTPUT_ERROR_DIR.mkdir(parents=True, exist_ok=True)
 
 
+def id_factory(source_dir: Path, namespace: str):
+    def create_id(filepath: Path | str) -> str:
+        subpath = Path(filepath).relative_to(source_dir).with_suffix("")
+        return f"{namespace}:{subpath}"
+
+    return create_id
+
+
 def bdo_to_lexoterm(bdo_dir: Path) -> Iterator[dict]:
     files = list(bdo_dir.rglob("*.xml"))
     bdo_transformer = BdoXmlTransformer()
     progress_bar = tqdm(files, desc="Converting BDO XML to LexoTerm format")
+    create_bdo_id = id_factory(bdo_dir, "bdo")
 
     for path in progress_bar:
         progress_bar.set_description(f"Processing {path.parent.parent.name}")
 
-        yield bdo_transformer.transform(path)
+        result = bdo_transformer.transform(path)
+        result["lexId"] = create_bdo_id(path)
+        yield result
 
 
 def dwds_to_lexoterm(dwds_dir: Path) -> Iterator[dict]:
     files = list(dwds_dir.rglob("*.xml"))
     dwds_transformer = DwdsXmlTransformer()
     progress_bar = tqdm(files, desc="Converting DWDS XML to LexoTerm format")
+    create_dwds_id = id_factory(dwds_dir, "dwds")
 
     for path in progress_bar:
         progress_bar.set_description(f"Processing {path.name}")
-        yield dwds_transformer.transform(path)
+        result = dwds_transformer.transform(path)
+        result["lexId"] = create_dwds_id(path)
+        yield result
 
 
 if __name__ == "__main__":

--- a/app/transformers/lex_transformer.py
+++ b/app/transformers/lex_transformer.py
@@ -3,11 +3,16 @@ from typing import Iterator
 
 from tqdm import tqdm
 
+from app.transformers.base_xml_transformer import BaseXmlTransformer
 from app.transformers.bdo.bdo_transformer import BdoXmlTransformer
 from app.transformers.dwds.dwds_transformer import DwdsXmlTransformer
 
 OUTPUT_DATA_DIR = Path("data/lexoterm")
 OUTPUT_ERROR_DIR = Path("data/lexoterm")
+TRANSFORMER_REGISTRY: dict[str, type[BaseXmlTransformer]] = {
+    "bdo": BdoXmlTransformer,
+    "dwds": DwdsXmlTransformer,
+}
 
 
 def ensure_output_directories():
@@ -15,38 +20,25 @@ def ensure_output_directories():
     OUTPUT_ERROR_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def id_factory(source_dir: Path, namespace: str):
-    def create_id(filepath: Path | str) -> str:
-        subpath = Path(filepath).relative_to(source_dir).with_suffix("")
-        return f"{namespace}:{subpath}"
+def create_id(namespace: str, source_dir: Path, filepath: Path | str):
+    subpath = Path(filepath).relative_to(source_dir).with_suffix("")
 
-    return create_id
+    return f"{namespace}:{subpath}"
 
 
-def bdo_to_lexoterm(bdo_dir: Path) -> Iterator[dict]:
-    files = list(bdo_dir.rglob("*.xml"))
-    bdo_transformer = BdoXmlTransformer()
-    progress_bar = tqdm(files, desc="Converting BDO XML to LexoTerm format")
-    create_bdo_id = id_factory(bdo_dir, "bdo")
+def transform(xml_dir: Path, resource_name: str) -> Iterator[dict]:
+    transformer = TRANSFORMER_REGISTRY[resource_name]()
+    files = list(xml_dir.rglob("*.xml"))
+    progress_bar = tqdm(files, desc="Converting XML to LexoTerm format")
 
-    for path in progress_bar:
-        progress_bar.set_description(f"Processing {path.parent.parent.name}")
+    for filepath in progress_bar:
+        progress_bar.set_description(f"Processing {filepath.parent.parent.name}")
 
-        result = bdo_transformer.transform(path)
-        result["lexId"] = create_bdo_id(path)
-        yield result
+        result = transformer.transform(filepath)
+        result["lexId"] = create_id(
+            namespace=resource_name, source_dir=xml_dir, filepath=filepath
+        )
 
-
-def dwds_to_lexoterm(dwds_dir: Path) -> Iterator[dict]:
-    files = list(dwds_dir.rglob("*.xml"))
-    dwds_transformer = DwdsXmlTransformer()
-    progress_bar = tqdm(files, desc="Converting DWDS XML to LexoTerm format")
-    create_dwds_id = id_factory(dwds_dir, "dwds")
-
-    for path in progress_bar:
-        progress_bar.set_description(f"Processing {path.name}")
-        result = dwds_transformer.transform(path)
-        result["lexId"] = create_dwds_id(path)
         yield result
 
 
@@ -57,7 +49,9 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Convert lexical resources to LexoTerm JSON"
     )
-    parser.add_argument("resource", help="Resource name", choices=["bdo", "dwds"])
+    parser.add_argument(
+        "resource", help="Resource name", choices=list(TRANSFORMER_REGISTRY)
+    )
     parser.add_argument(
         "-p", "--path", help="Path to source folder", required=True, type=Path
     )
@@ -67,12 +61,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    dispatch = {
-        "bdo": bdo_to_lexoterm,
-        "dwds": dwds_to_lexoterm,
-    }
-
-    result = dispatch[args.resource](args.path)
+    result = transform(args.path, args.resource)
 
     ensure_output_directories()
 

--- a/app/transformers/lex_transformer.py
+++ b/app/transformers/lex_transformer.py
@@ -28,7 +28,7 @@ def create_id(namespace: str, source_dir: Path, filepath: Path | str):
 
 
 def transform(
-    xml_dir: Path, resource_name: str, *, retrieved_at: Optional[str] = None
+    xml_dir: Path, resource_name: str, *, retrieved_at: date | None = None
 ) -> Iterator[dict]:
     transformer = TRANSFORMER_REGISTRY[resource_name]()
     files = list(xml_dir.rglob("*.xml"))
@@ -43,7 +43,7 @@ def transform(
         )
 
         if retrieved_at is not None:
-            result["retrievedAt"] = date.fromisoformat(retrieved_at)
+            result["retrievedAt"] = retrieved_at.isoformat()
 
         yield result
 
@@ -64,10 +64,15 @@ if __name__ == "__main__":
     parser.add_argument(
         "-o", "--out", help="Path to output file (jsonl-format)", type=Path
     )
+    parser.add_argument(
+        "--retrieved-at",
+        help="Retrieval data (iso format, e.g. '2026-04-23')",
+        type=date.fromisoformat,
+    )
 
     args = parser.parse_args()
 
-    result = transform(args.path, args.resource)
+    result = transform(args.path, args.resource, retrieved_at=args.retrieved_at)
 
     ensure_output_directories()
 

--- a/app/transformers/lex_transformer.py
+++ b/app/transformers/lex_transformer.py
@@ -30,14 +30,15 @@ def create_id(namespace: str, source_dir: Path, filepath: Path | str):
 def transform(
     xml_dir: Path, resource_name: str, *, retrieved_at: date | None = None
 ) -> Iterator[dict]:
-    transformer = TRANSFORMER_REGISTRY[resource_name]()
+    Transformer = TRANSFORMER_REGISTRY[resource_name]()  # noqa: N806
+
     files = list(xml_dir.rglob("*.xml"))
     progress_bar = tqdm(files, desc="Converting XML to LexoTerm format")
 
     for filepath in progress_bar:
         progress_bar.set_description(f"Processing {filepath.parent.parent.name}")
 
-        result = transformer.transform(filepath)
+        result = Transformer.transform(filepath)
         result["lexId"] = create_id(
             namespace=resource_name, source_dir=xml_dir, filepath=filepath
         )

--- a/app/transformers/lex_transformer.py
+++ b/app/transformers/lex_transformer.py
@@ -1,5 +1,6 @@
+from datetime import date
 from pathlib import Path
-from typing import Iterator
+from typing import Iterator, Optional
 
 from tqdm import tqdm
 
@@ -26,7 +27,9 @@ def create_id(namespace: str, source_dir: Path, filepath: Path | str):
     return f"{namespace}:{subpath}"
 
 
-def transform(xml_dir: Path, resource_name: str) -> Iterator[dict]:
+def transform(
+    xml_dir: Path, resource_name: str, *, retrieved_at: Optional[str] = None
+) -> Iterator[dict]:
     transformer = TRANSFORMER_REGISTRY[resource_name]()
     files = list(xml_dir.rglob("*.xml"))
     progress_bar = tqdm(files, desc="Converting XML to LexoTerm format")
@@ -38,6 +41,9 @@ def transform(xml_dir: Path, resource_name: str) -> Iterator[dict]:
         result["lexId"] = create_id(
             namespace=resource_name, source_dir=xml_dir, filepath=filepath
         )
+
+        if retrieved_at is not None:
+            result["retrievedAt"] = date.fromisoformat(retrieved_at)
 
         yield result
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ test = "pytest"
 dev = "uv run fastapi dev"
 upload = "python -m app.services.import_service"
 transform = "python -m app.transformers.lex_transformer"
+validate = "python -m app.transformers.lex_validator"
 
 [tool.poe.tasks.check]
 sequence = [


### PR DESCRIPTION
1. Replace old id generation logic with path-based ids
    - Ids are readable
    - Ids are persistent across transformations
    - Ids are _not_ persistent across data versions: If the contents of a file changes, the same id may point to a different lemma
    - Paths as ids may cause trouble in urls due to slashes `/` (hence requiring `:path` in [cfbbca0](https://github.com/pdl-lex/pdl-api/commit/cfbbca01bd85600a03c19bdb6659d267f4882aa7)) -> maybe use a different delimiter in the future or pass ids as query parameter (`/lemma?id=...` instead of `/lemma/{id}`)
2. Add `retrieved_at` to track source data state
3. Speed up transformation via parallelizationd